### PR TITLE
Added comment character to syntax

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -15,6 +15,15 @@
 				<key>value</key>
 				<string>$ </string>
 			</dict>
+			<!-- The disabling of indention was found under the following link:
+					https://forum.sublimetext.com/t/comment-character-at-the-beginning-of-the-line/9886/2
+			  -->
+			<dict>
+			    <key>name</key>
+			    <string>TM_COMMENT_DISABLE_INDENT</string>
+			    <key>value</key>
+			    <string>yes</string>
+			</dict>			
 		</array>
 	</dict>
 </dict>

--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Comments</string>
+	<key>scope</key>
+	<string>source.lsdyna</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string>$ </string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
With the new added Comments.tmPreferences, it is now possible to use the Sublime commands 'Toggle Comment' and 'Toggle Block Comment'.